### PR TITLE
Ignore completed event

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ let moment = require('moment-timezone');
 exports.constructAttachments = (statuses, now, timezone) => {
   return statuses.map(status => {
     return status.Events.map(event => {
+      if (event.Description.match(/^\[Completed\]/)) {
+        return null;
+      }
+
       let color = event.NotBefore > now ? 'warning' : 'danger';
       let eventFrom = event.NotBefore == undefined ? '' : moment(event.NotBefore).tz(timezone).format('YYYY-MM-DD kk:mm:ss ZZ');
       let eventTo = event.NotAfter == undefined ? '' : moment(event.NotAfter).tz(timezone).format('YYYY-MM-DD kk:mm:ss ZZ');
@@ -38,7 +42,7 @@ exports.constructAttachments = (statuses, now, timezone) => {
         ],
       };
     });
-  }).filter(a => a.length > 0).reduce((r, v) => r.concat(v), []);
+  }).filter(a => a.length > 0).reduce((r, v) => r.concat(v), []).filter(a => a != null);
 }
 
 exports.handler = (event, context, callback) => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -67,6 +67,39 @@ describe('constructAttachments', () => {
         Status: 'ok',
       },
     },
+    {
+      AvailabilityZone: 'ap-northeast-1c',
+      Events: [
+        {
+          Code: 'instance-stop',
+          Description: '[Completed] The instance is running on degraded hardware',
+          NotBefore: new Date("2017-09-10 17:25:52 +0900"),
+        }
+      ],
+      InstanceId: 'i-e24b95371adf0186c',
+      InstanceState: {
+        Code: 16,
+        Name: 'running',
+      },
+      InstanceStatus: {
+        Details: [
+          {
+            Name: 'reachability',
+            Status: 'passed',
+          },
+        ],
+        Status: 'ok',
+      },
+      SystemStatus: {
+        Details: [
+          {
+            Name: 'reachability',
+            Status: 'passed',
+          },
+        ],
+        Status: 'ok',
+      },
+    },
   ];
   let now = new Date("2017-09-01 12:34:56 +0900");
   let timezone = 'Asia/Tokyo';


### PR DESCRIPTION
## WHY

Now **completed** events are still notified.

![image](https://user-images.githubusercontent.com/680124/30314314-53c1627c-97db-11e7-8c4d-62838d1ce48a.png)

We have nothing to do for these events, however this notification will be shown for a week.

http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-instances-status-check_sched.html

> Completed maintenance events are displayed on the Amazon EC2 console dashboard for up to a week.

## WHAT

Do not notify completed scheduled events.